### PR TITLE
Feat/Update order tracking

### DIFF
--- a/src/components/common/confirm-dialog.tsx
+++ b/src/components/common/confirm-dialog.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -7,26 +9,36 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
 
 interface ConfirmDialogProps {
   open: boolean;
+  isLoading?: boolean;
   onOpenChange: (open: boolean) => void;
   title: string;
   description: string;
-  onConfirm: () => void;
+  onConfirm: (reason?: string) => void;
   confirmText?: string;
   cancelText?: string;
+  reasonRequired?: boolean;
+  reasonLabel?: string;
 }
 
 export function ConfirmDialog({
   open,
+  isLoading = false,
   onOpenChange,
   title,
   description,
   onConfirm,
   confirmText = "Xác nhận",
   cancelText = "Hủy",
+  reasonRequired = false,
+  reasonLabel = "Lý do",
 }: ConfirmDialogProps) {
+  const [reason, setReason] = useState("");
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
@@ -34,11 +46,35 @@ export function ConfirmDialog({
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
+        {reasonRequired && (
+          <div className="grid gap-2 py-2">
+            <Label htmlFor="confirm-reason">{reasonLabel}</Label>
+            <Textarea
+              id="confirm-reason"
+              placeholder={`Nhập ${reasonLabel.toLowerCase()}`}
+              value={reason}
+              onChange={(e) => {
+                setReason(e.target.value);
+              }}
+              className="min-h-[80px]"
+              required={reasonRequired}
+            />
+          </div>
+        )}
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <Button
+            variant="outline"
+            disabled={isLoading}
+            onClick={() => onOpenChange(false)}
+          >
             {cancelText}
           </Button>
-          <Button variant="destructive" onClick={onConfirm}>
+          <Button
+            variant="destructive"
+            isLoading={isLoading}
+            disabled={isLoading || (reasonRequired && !reason)}
+            onClick={() => onConfirm(reason)}
+          >
             {confirmText}
           </Button>
         </DialogFooter>

--- a/src/components/icons/glyphs/check-circle2.tsx
+++ b/src/components/icons/glyphs/check-circle2.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+
+export function CheckCircle2({
+  width = 20,
+  height = 20,
+  className,
+  ...props
+}: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      {...props}
+    >
+      <path
+        d="M9 12.75L11.25 15L15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export default CheckCircle2;

--- a/src/components/icons/glyphs/index.ts
+++ b/src/components/icons/glyphs/index.ts
@@ -27,10 +27,18 @@ import { HalfStar } from "./half-star";
 import { Camera } from "./camera";
 import { BookMark } from "./book-mark";
 import { Trash } from "./trash";
+import CheckCircle2 from "./check-circle2";
+import NoteComplete from "./note-complete";
+import WarningCircle from "./warning-circle";
+import OrderCancel from "./order-cancel";
 
 export const glyphs = {
   alertCircle: AlertCircle,
   checkCircle: CheckCircle,
+  checkCircle2: CheckCircle2,
+  noteComplete: NoteComplete,
+  warningCircle: WarningCircle,
+  orderCancel: OrderCancel,
   eye: Eye,
   facebook: FacebookIcon,
   instagram: InstagramIcon,

--- a/src/components/icons/glyphs/note-complete.tsx
+++ b/src/components/icons/glyphs/note-complete.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+
+export function NoteComplete({
+  width = 64,
+  height = 64,
+  className,
+  ...props
+}: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      {...props}
+    >
+      <path
+        d="M19.5 5.25H4.5C4.08579 5.25 3.75 5.58579 3.75 6V18C3.75 18.4142 4.08579 18.75 4.5 18.75H19.5C19.9142 18.75 20.25 18.4142 20.25 18V6C20.25 5.58579 19.9142 5.25 19.5 5.25Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M16.5 5.25V3.75C16.5 3.33579 16.1642 3 15.75 3H8.25C7.83579 3 7.5 3.33579 7.5 3.75V5.25"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M9 12.75L11.25 15L15 9.75"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export default NoteComplete;

--- a/src/components/icons/glyphs/order-cancel.tsx
+++ b/src/components/icons/glyphs/order-cancel.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+
+export function OrderCancel({
+  width = 64,
+  height = 64,
+  className,
+  ...props
+}: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      {...props}
+    >
+      <path
+        d="M19.5 5.25H4.5C4.08579 5.25 3.75 5.58579 3.75 6V18C3.75 18.4142 4.08579 18.75 4.5 18.75H19.5C19.9142 18.75 20.25 18.4142 20.25 18V6C20.25 5.58579 19.9142 5.25 19.5 5.25Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6 10L18 10"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M9.75 13.5L14.25 13.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export default OrderCancel;

--- a/src/components/icons/glyphs/warning-circle.tsx
+++ b/src/components/icons/glyphs/warning-circle.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+
+export function WarningCircle({
+  width = 20,
+  height = 20,
+  className,
+  ...props
+}: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      {...props}
+    >
+      <path
+        d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export default WarningCircle;

--- a/src/constants/vi-locations.ts
+++ b/src/constants/vi-locations.ts
@@ -1,60 +1,17 @@
-export const PROVINCES = [
-  "Hà Nội",
-  "Hồ Chí Minh",
-  "Đà Nẵng",
-  "Cần Thơ"
-];
+export const PROVINCES = ["Hà Nội", "Hồ Chí Minh", "Đà Nẵng", "Cần Thơ"];
 
 export const DISTRICT_BY_PROVINCES: Record<string, string[]> = {
-  "Hà Nội": [
-    "Hoàn Kiếm",
-    "Ba Đình",
-    "Đống Đa",
-    "Cầu Giấy"
-  ],
-  "Hồ Chí Minh": [
-    "Quận 1",
-    "Quận 3",
-    "Bình Thạnh",
-    "Phú Nhuận"
-  ],
-  "Đà Nẵng": [
-    "Hải Châu",
-    "Sơn Trà",
-    "Thanh Khê",
-    "Cẩm Lệ",
-  ],
-  "Cần Thơ": [
-    "Ninh Kiều",
-    "Bình Thủy",
-    "Cái Răng"
-  ]
+  "Hà Nội": ["Hoàn Kiếm", "Ba Đình", "Đống Đa", "Cầu Giấy"],
+  "Hồ Chí Minh": ["Quận 1", "Quận 3", "Bình Thạnh", "Phú Nhuận"],
+  "Đà Nẵng": ["Hải Châu", "Sơn Trà", "Thanh Khê", "Cẩm Lệ"],
+  "Cần Thơ": ["Ninh Kiều", "Bình Thủy", "Cái Răng"],
 };
 
 export const WARDS_BY_DISTRICT: Record<string, string[]> = {
-  "Hoàn Kiếm": [
-    "Phúc Tân",
-    "Đồng Xuân",
-    "Hàng Bạc"
-  ],
-  "Ba Đình": [
-    "Cống Vị",
-    "Điện Biên",
-    "Kim Mã"
-  ],
-  "Quận 1": [
-    "Bến Nghé",
-    "Bến Thành",
-    "Phạm Ngũ Lão"
-  ],
-  "Quận 3": [
-    "Võ Thị Sáu",
-    "Phường 10",
-    "Phường 11"
-  ],
-  "Cẩm Lệ": [
-    "Hòa An",
-    "Hòa Phát",
-    "Hòa Thọ Đông"
-  ]
+  "Hoàn Kiếm": ["Phúc Tân", "Đồng Xuân", "Hàng Bạc"],
+  "Ba Đình": ["Cống Vị", "Điện Biên", "Kim Mã"],
+  "Quận 1": ["Bến Nghé", "Bến Thành", "Phạm Ngũ Lão"],
+  "Quận 3": ["Võ Thị Sáu", "Phường 10", "Phường 11"],
+  "Cẩm Lệ": ["Hòa An", "Hòa Phát", "Hòa Thọ Đông"],
+  "Hải Châu": ["Thạch Thang", "Thanh Bình","Thuận Phước"],
 };

--- a/src/features/order/api/index.ts
+++ b/src/features/order/api/index.ts
@@ -3,7 +3,7 @@ import type {
   CheckoutResponse,
   CreateOrderRequest,
   CreateOrderResponse,
-  GetOrderResponse,
+  Order,
   UpdateOrderRequest,
   UpdateOrderResponse,
 } from "../types/orders.type";
@@ -44,7 +44,7 @@ export const orderApi = {
     }
   },
 
-  getOrder: async (orderId: string): Promise<GetOrderResponse> => {
+  getOrder: async (orderId: string): Promise<Order> => {
     try {
       const response = await axiosInstance.get(
         `${ORDER_ENDPOINTS.GET_ORDER}${orderId}`

--- a/src/features/order/constants/order-dialog-message.ts
+++ b/src/features/order/constants/order-dialog-message.ts
@@ -1,0 +1,12 @@
+const ORDER_DIALOG_MESSAGE = {
+  PENDING: {
+    title: "Xác nhận hủy đặt dịch vụ",
+    description: "Vui lòng nhập lý do hủy đơn đặt này.",
+  },
+  PROCESSING: {
+    title: "Xác nhận hoàn thành dịch vụ",
+    description: "Bạn có chắc chắn dịch vụ này đã được hoàn thành không?",
+  },
+};
+
+export default ORDER_DIALOG_MESSAGE;

--- a/src/features/order/constants/order-notfound-message.ts
+++ b/src/features/order/constants/order-notfound-message.ts
@@ -1,0 +1,14 @@
+const ORDER_NOT_FOUND_MESSAGE = {
+  404: {
+    title: "Dịch vụ không tồn tại",
+    description: "Không tìm thấy dịch vụ bạn tìm kiếm hoặc có thể đã bị xóa.",
+    buttonText: "Quay lại trang chủ",
+  },
+  403: {
+    title: "Không có quyền truy cập",
+    description: "Cửa hàng không thể tự đặt dịch vụ của mình.",
+    buttonText: "Quay lại trang chủ",
+  },
+};
+
+export default ORDER_NOT_FOUND_MESSAGE;

--- a/src/features/order/service/order.service.ts
+++ b/src/features/order/service/order.service.ts
@@ -35,7 +35,7 @@ export const orderServices = {
 
   async getOrder(orderId: string): Promise<Order> {
     const response = await orderApi.getOrder(orderId);
-    return response.order;
+    return response;
   },
 
   async updateOrder(

--- a/src/features/order/types/orders.type.ts
+++ b/src/features/order/types/orders.type.ts
@@ -81,10 +81,10 @@ export type Order = {
   updated_at: string;
   service: OrderService;
   customer: OrderCustomer;
-};
-
-export type GetOrderResponse = {
-  order: Order;
+  created_description: string | null;
+  customer_cancelled_description: string | null;
+  store_cancelled_description: string | null;
+  completed_description: string | null;
 };
 
 export type UpdateOrderRequest = {

--- a/src/pages/order/creation/_components/customer-information-section.tsx
+++ b/src/pages/order/creation/_components/customer-information-section.tsx
@@ -1,14 +1,14 @@
-import { useEffect } from "react";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
 import TextareaField from "@/components/common/textarea-field";
 import SelectField from "@/components/common/select-field";
 import { useSelectLocation } from "@/hooks/useSelectLocation";
-import type { UserAddress } from "@/types/service";
 import { UseFormReturn } from "react-hook-form";
-import type { OrderFormData } from "@/schemas/order";
 import FileUpload from "@/components/common/upload-file";
+
+import type { OrderFormData } from "@/schemas/order";
+import type { UserAddress } from "@/types/service";
 
 interface CustomerInformationProps {
   customer: UserAddress;
@@ -25,10 +25,14 @@ export default function CustomerInformationSection({
     provinces,
     districts,
     wards,
-    handleProvinceChange,
-    handleDistrictChange,
-    handleWardChange,
-  } = useSelectLocation();
+    handleProvinceChange: provinceChangeHandler,
+    handleDistrictChange: districtChangeHandler,
+    handleWardChange: wardChangeHandler,
+  } = useSelectLocation({
+    initialProvince: customer.user_city,
+    initialDistrict: customer.user_district,
+    initialWard: customer.user_ward,
+  });
 
   const {
     register,
@@ -36,13 +40,23 @@ export default function CustomerInformationSection({
     formState: { errors },
   } = form;
 
-  useEffect(() => {
-    handleProvinceChange(customer.user_city);
-    handleDistrictChange(customer.user_district);
-    handleWardChange(customer.user_ward);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [customer.user_city, customer.user_district, customer.user_ward]);
+  const handleProvinceChange = (value: string) => {
+    provinceChangeHandler(value);
+    setValue("user_city", value, { shouldValidate: true });
+    setValue("user_district", "", { shouldValidate: true });
+    setValue("user_ward", "", { shouldValidate: true });
+  };
 
+  const handleDistrictChange = (value: string) => {
+    districtChangeHandler(value);
+    setValue("user_district", value, { shouldValidate: true });
+    setValue("user_ward", "", { shouldValidate: true });
+  };
+
+  const handleWardChange = (value: string) => {
+    wardChangeHandler(value);
+    setValue("user_ward", value, { shouldValidate: true });
+  };
 
   return (
     <Card className="p-6 space-y-6">

--- a/src/pages/order/creation/index.tsx
+++ b/src/pages/order/creation/index.tsx
@@ -10,6 +10,7 @@ import CustomerInformationSection from "./_components/customer-information-secti
 import ServiceInformationSection from "./_components/service-information-section";
 import { useNavigate } from "react-router-dom";
 import routePath from "@/config/route";
+import ORDER_NOT_FOUND_MESSAGE from "@/features/order/constants/order-notfound-message";
 
 export default function ServiceBookingForm() {
   const { customer, service, errorMessage, status } = useCheckout();
@@ -53,7 +54,7 @@ export default function ServiceBookingForm() {
     }
   };
 
-  if (errorMessage && status != 404) {
+  if (errorMessage && status != 404 && status != 403) {
     toast.error(errorMessage, {
       toastId: errorMessage,
     });
@@ -61,11 +62,12 @@ export default function ServiceBookingForm() {
 
   return (
     <>
-      {status === 404 ? (
+      {status === 404 || status === 403 ? (
         <ResourceNotFound
-          title="Dịch vụ không tồn tại"
-          description="Không tìm thấy dịch vụ bạn tìm kiếm hoặc có thể đã bị xóa."
-          buttonText="Quay lại trang chủ"
+          title={ORDER_NOT_FOUND_MESSAGE[status].title}
+          description={ORDER_NOT_FOUND_MESSAGE[status].description}
+          buttonText={ORDER_NOT_FOUND_MESSAGE[status].buttonText}
+          onButtonClick={() => navigate(routePath.home)}
         />
       ) : (
         <form onSubmit={form.handleSubmit(onSubmit)}>

--- a/src/pages/order/tracking/_components/customer-information.tsx
+++ b/src/pages/order/tracking/_components/customer-information.tsx
@@ -44,7 +44,7 @@ export default function CustomerInformation({
       customer_full_name: order.customer_full_name,
       customer_phone_number: order.customer_phone_number,
       customer_address: order.customer_address,
-      order_description: order.order_description,
+      order_description: order.created_description || "",
       order_images: images,
     },
   });
@@ -86,9 +86,6 @@ export default function CustomerInformation({
         order_status: "PENDING" as OrderStatus,
         order_images: orderImages,
       };
-
-      // Log payload to verify images are included
-      console.log("Submitting with images:", orderImages.length);
 
       const updatedOrder = await updateOrder(
         order.order_id.toString(),
@@ -207,7 +204,7 @@ export default function CustomerInformation({
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="order_description">Mô tả chi tiết lỗi</Label>
+              <Label htmlFor="order_description">Chi tiết lỗi</Label>
               <Textarea
                 id="order_description"
                 disabled={!isEditing || isLoading || isDisabled}

--- a/src/pages/order/tracking/_components/order-actions.tsx
+++ b/src/pages/order/tracking/_components/order-actions.tsx
@@ -1,11 +1,15 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import type { Order, OrderStatus } from "@/features/order/types/orders.type";
-import { toast } from "react-toastify";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import ORDER_DIALOG_MESSAGE from "@/features/order/constants/order-dialog-message";
 import { useOrder } from "@/features/order/hooks/useOrder";
 import routePath from "@/config/route";
+
+import { toast } from "react-toastify";
+
+import type { Order, OrderStatus } from "@/features/order/types/orders.type";
+import type { DialogContent } from "@/types/globals.type";
 
 interface OrderActionsProps {
   orderId: number;
@@ -19,20 +23,51 @@ export default function OrderActions({
   onOrderUpdated,
 }: OrderActionsProps) {
   const navigate = useNavigate();
-  const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
+  const [dialogActions, setDialogActions] = useState<DialogContent | null>(
+    null
+  );
   const { updateOrder, isLoading } = useOrder();
 
-  const handleCancelOrder = async () => {
+  const handleCancelOrder = async (reason?: string) => {
     try {
       const updatedOrder = await updateOrder(orderId.toString(), {
         order_status: "CANCELED",
+        order_description: reason,
       });
       toast.success("Đơn hàng đã được hủy thành công");
-      setIsCancelModalOpen(false);
+      setDialogActions(null);
       onOrderUpdated(updatedOrder);
     } catch {
       toast.error("Có lỗi xảy ra khi hủy đặt dịch vụ");
     }
+  };
+
+  const handleCompleteOrder = async () => {
+    try {
+      const updatedOrder = await updateOrder(orderId.toString(), {
+        order_status: "COMPLETED",
+      });
+      toast.success("Đơn hàng đã được đánh dấu hoàn thành thành công");
+      setDialogActions(null);
+      onOrderUpdated(updatedOrder);
+    } catch {
+      toast.error("Có lỗi xảy ra khi đánh dấu hoàn thành đơn hàng");
+    }
+  };
+
+  const handleConfirmDialog = (status: string) => {
+    setDialogActions({
+      isOpen: true,
+      title:
+        ORDER_DIALOG_MESSAGE[status as keyof typeof ORDER_DIALOG_MESSAGE].title,
+      description:
+        ORDER_DIALOG_MESSAGE[status as keyof typeof ORDER_DIALOG_MESSAGE]
+          .description,
+      onConfirm:
+        status === "PROCESSING" ? handleCompleteOrder : handleCancelOrder,
+      reasonRequired: status === "PENDING",
+      reasonLabel: "Lý do hủy đơn",
+    });
   };
 
   const handleBack = () => {
@@ -43,7 +78,7 @@ export default function OrderActions({
     <div className="flex flex-wrap gap-3">
       {status === "PENDING" && (
         <Button
-          onClick={() => setIsCancelModalOpen(true)}
+          onClick={() => handleConfirmDialog("PENDING")}
           variant="outline"
           className="border-red-500 text-red-600 hover:bg-red-50"
           disabled={isLoading}
@@ -51,15 +86,32 @@ export default function OrderActions({
           Hủy đơn
         </Button>
       )}
+      {status === "PROCESSING" && (
+        <Button
+          onClick={() => handleConfirmDialog("PROCESSING")}
+          variant="outline"
+          className="border-green-500 text-green-600 hover:bg-green-50"
+          disabled={isLoading}
+        >
+          Xác nhận đã hoàn thành
+        </Button>
+      )}
       <Button onClick={handleBack} variant="outline">
         Quay lại
       </Button>
       <ConfirmDialog
-        open={isCancelModalOpen}
-        onOpenChange={setIsCancelModalOpen}
-        title="Xác nhận hủy đặt dịch vụ"
-        description="Bạn có chắc chắn muốn hủy đặt dịch vụ này không?"
-        onConfirm={handleCancelOrder}
+        open={dialogActions?.isOpen ?? false}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            setDialogActions(null);
+          }
+        }}
+        isLoading={isLoading}
+        title={dialogActions?.title ?? ""}
+        description={dialogActions?.description ?? ""}
+        onConfirm={dialogActions?.onConfirm || (() => {})}
+        reasonRequired={dialogActions?.reasonRequired ?? false}
+        reasonLabel={dialogActions?.reasonLabel ?? "Lý do"}
       />
     </div>
   );

--- a/src/pages/order/tracking/_components/order-status-bar.tsx
+++ b/src/pages/order/tracking/_components/order-status-bar.tsx
@@ -1,9 +1,11 @@
-import type { OrderStatus } from "@/features/order/types/orders.type";
+import type { Order, OrderStatus } from "@/features/order/types/orders.type";
 import type { Role } from "@/types/globals.type";
+import Icon from "@/components/icons";
 
 interface OrderStatusBarProps {
   status: OrderStatus;
   role: Role;
+  order?: Order;
 }
 
 const getStatusConfig = (status: OrderStatus, role: Role) => {
@@ -53,16 +55,74 @@ const getStatusConfig = (status: OrderStatus, role: Role) => {
   }
 };
 
-export default function OrderStatusBar({ status, role }: OrderStatusBarProps) {
+export default function OrderStatusBar({
+  status,
+  role,
+  order,
+}: OrderStatusBarProps) {
   const { color, label, description } = getStatusConfig(status, role);
+  const CANCEL_DESCRIPTION = {
+    STORE: order?.customer_cancelled_description,
+    CUSTOMER: order?.store_cancelled_description,
+  };
+
+  // Determine if the cancellation reason should be shown
+  const showCancelReason =
+    status === "CANCELED" &&
+    order &&
+    ((role !== "STORE" && order.store_cancelled_description) ||
+      (role === "STORE" && order.customer_cancelled_description));
+
+  // Determine if the completion note should be shown
+  const showCompletionNote =
+    status === "COMPLETED" && order?.completed_description;
 
   return (
     <div className="rounded-lg p-4 shadow-sm border border-gray-100">
-      <div className="flex items-center gap-4">
-        <div className={`px-3 py-1 rounded-full font-medium ${color}`}>
-          {label}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-4">
+          <div className={`px-3 py-1 rounded-full font-medium ${color}`}>
+            {label}
+          </div>
+          <div className="text-gray-600">{description}</div>
         </div>
-        <div className="text-gray-600">{description}</div>
+        {showCancelReason && (
+          <div className="mt-3 pt-3 border-t border-gray-100">
+            <div className="flex items-center mb-2">
+              <Icon glyph="warningCircle" className="text-red-600 mr-2" />
+              <div className="text-red-700 font-medium">Lý do hủy</div>
+            </div>
+            <div className="bg-red-50 p-4 rounded-lg border border-red-100 text-gray-700 relative overflow-hidden">
+              <div className="relative z-10">
+                <span className="font-medium">
+                  {role === "STORE" ? "Khách hàng" : "Cửa hàng"}:
+                </span>{" "}
+                {CANCEL_DESCRIPTION[role as keyof typeof CANCEL_DESCRIPTION]}
+              </div>
+              <div className="absolute top-0 right-0 w-16 h-16 opacity-10">
+                <Icon glyph="orderCancel" className="text-red-500" />
+              </div>
+            </div>
+          </div>
+        )}
+        {showCompletionNote && role === "STORE" && (
+          <div className="mt-3 pt-3 border-t border-gray-100">
+            <div className="flex items-center mb-2">
+              <Icon glyph="checkCircle2" className="text-blue-600 mr-2" />
+              <div className="text-blue-700 font-medium">
+                Ghi chú hoàn thành
+              </div>
+            </div>
+            <div className="bg-blue-50 p-4 rounded-lg border border-blue-100 text-gray-700 relative overflow-hidden">
+              <div className="relative z-10">
+                {order?.completed_description}
+              </div>
+              <div className="absolute top-0 right-0 w-16 h-16 opacity-10">
+                <Icon glyph="noteComplete" className="text-blue-500" />
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/pages/order/tracking/_components/service-information.tsx
+++ b/src/pages/order/tracking/_components/service-information.tsx
@@ -48,7 +48,12 @@ export default function ServiceInformation({ order }: ServiceInformationProps) {
               <span className="inline-block mr-2">
                 <Icon glyph="phone" className="size-4" />
               </span>
-              {order.store_phone_number}
+              <a
+                href={`tel:${order.store_phone_number}`}
+                className="hover:underline"
+              >
+                {order.store_phone_number}
+              </a>
             </p>
           </div>
         </div>

--- a/src/pages/order/tracking/_components/store-order-actions.tsx
+++ b/src/pages/order/tracking/_components/store-order-actions.tsx
@@ -83,15 +83,17 @@ export default function StoreOrderActions({
     }
   };
 
-  const handleCancelOrder = async () => {
+  const handleCancelOrder = async (reason?: string) => {
     try {
       const updatedOrder = await updateOrder(order.order_id.toString(), {
         order_status: "CANCELED",
+        order_description: reason,
       });
 
       if (updatedOrder) {
         toast.success(SUCCESS_MESSAGES["CANCELED"]);
         onOrderUpdated(updatedOrder);
+        setIsConfirmModalOpen(false);
       }
     } catch {
       toast.error("Có lỗi xảy ra khi hủy đơn đặt dịch vụ!");
@@ -156,7 +158,7 @@ export default function StoreOrderActions({
                 Tạm thời không có nhân viên
               </p>
             )}
-            <div className="flex gap-3 mt-4">
+            <div className="flex gap-3 pt-2">
               <Button
                 type="submit"
                 disabled={isLoading || employeeOptions.length === 0}
@@ -214,10 +216,13 @@ export default function StoreOrderActions({
       </CardContent>
       <ConfirmDialog
         open={isConfirmModalOpen}
+        isLoading={isLoading}
         onOpenChange={setIsConfirmModalOpen}
         title="Xác nhận huỷ đơn đặt dịch vụ"
-        description="Bạn có muốn hủy đơn đặt dịch vụ này?"
+        description="Vui lòng nhập lý do hủy đơn hàng này."
         onConfirm={handleCancelOrder}
+        reasonRequired
+        reasonLabel="Lý do hủy đơn"
       />
     </Card>
   );

--- a/src/pages/order/tracking/_components/technician-information.tsx
+++ b/src/pages/order/tracking/_components/technician-information.tsx
@@ -1,4 +1,4 @@
-import { Order } from "@/features/order/types/orders.type";
+import type { Order } from "@/features/order/types/orders.type";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 
 interface TechnicianInformationProps {
@@ -14,54 +14,40 @@ export default function TechnicianInformation({
   );
 
   return (
-    <div className="flex flex-col gap-2 p-6">
-      <h3 className="font-semibold">Thông tin kỹ thuật viên</h3>
+    <div className="flex flex-col gap-3 p-6 rounded-lg bg-white shadow-sm">
+      <h3 className="text-base font-semibold">Thông tin kỹ thuật viên</h3>
       <div className="text-sm text-gray-600">
         Chi tiết về kỹ thuật viên được phân công xử lý đơn hàng của bạn
       </div>
-      {order.order_status === "PROCESSING" && order.employee_full_name ? (
-        <div className="flex items-start gap-4">
-          <Avatar className="size-12 rounded-full border border-gray-200">
+      {(order.order_status === "PROCESSING" ||
+        order.order_status === "COMPLETED") &&
+      order.employee_full_name ? (
+        <div className="flex flex-col sm:flex-row items-start gap-4 mt-2">
+          <Avatar className="size-14 rounded-full border border-gray-200 shrink-0">
             {employee?.employee_avatar_url ? (
               <img
                 src={employee.employee_avatar_url}
                 alt={order.employee_full_name}
-                className="object-cover"
+                className="object-cover w-full h-full"
               />
             ) : (
-              <AvatarFallback>
+              <AvatarFallback className="text-lg">
                 {order.employee_full_name.charAt(0)}
               </AvatarFallback>
             )}
           </Avatar>
-          <div>
-            <div className="mb-4">
-              <h3 className="font-medium">Họ và tên</h3>
-              <p className="text-lg font-semibold">
+          <div className="flex flex-col w-full space-y-4">
+            <div>
+              <h3 className="text-sm font-medium text-gray-500">Họ và tên</h3>
+              <p className="text-base font-semibold mt-1">
                 {order.employee_full_name}
               </p>
-            </div>
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <div>
-                <h3 className="font-medium">Kinh nghiệm</h3>
-                <p className="text-sm text-gray-600">
-                  {employee?.employee_id
-                    ? "5 năm kinh nghiệm sửa chữa điện lạnh"
-                    : "Chưa có thông tin"}
-                </p>
-              </div>
-              <div>
-                <h3 className="font-medium">Số điện thoại</h3>
-                <p className="text-sm text-blue-600 hover:underline">
-                  {order.store_phone_number}
-                </p>
-              </div>
             </div>
           </div>
         </div>
       ) : (
-        <div className="flex items-center justify-center h-full">
-          <p className="text-gray-500">
+        <div className="flex items-center justify-center h-24 bg-gray-50 rounded-md mt-2">
+          <p className="text-gray-500 text-sm">
             Không có kỹ thuật viên nào được phân công
           </p>
         </div>

--- a/src/pages/order/tracking/index.tsx
+++ b/src/pages/order/tracking/index.tsx
@@ -52,9 +52,12 @@ export default function OrderTracking() {
         <h1 className="text-2xl font-bold mb-2">
           Chi tiết đơn đặt dịch vụ #{order.order_id}
         </h1>
-        <OrderStatusBar status={order.order_status} role={user?.role as Role} />
+        <OrderStatusBar
+          status={order.order_status}
+          role={user?.role as Role}
+          order={order}
+        />
       </div>
-
       {isStore ? (
         <StoreOrderActions order={order} onOrderUpdated={onUpdateOrder} />
       ) : (

--- a/src/schemas/order.ts
+++ b/src/schemas/order.ts
@@ -73,6 +73,18 @@ export const storeUpdateOrderSchema = z
       message: "Vui lòng chọn nhân viên",
       path: ["employee_id"],
     }
+  )
+  .refine(
+    (data) => {
+      if (data.order_status === "CANCELED") {
+        return !!data.order_description;
+      }
+      return true;
+    },
+    {
+      message: "Vui lòng nhập lý do hủy đơn",
+      path: ["order_description"],
+    }
   );
 
 export type OrderFormData = z.infer<typeof orderFormSchema>;

--- a/src/types/globals.type.ts
+++ b/src/types/globals.type.ts
@@ -24,3 +24,12 @@ export interface AxiosResponse<T = undefined> {
 }
 
 export type Role = "STORE" | "USER" | "ADMIN";
+
+export type DialogContent = {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  onConfirm: () => void;
+  reasonRequired?: boolean;
+  reasonLabel?: string;
+};


### PR DESCRIPTION
## What?
- Update order tracking
  - Client / Store can view cancel order reason
  - Adjust UI when at status `CANCEL` and `COMPLETE`
  - Update get order response to match with API. from wrap data by `order: {}` to non-wrap
  - Update dialog confirm components to show input for user can enter cancel reason.
  - Handle case store booking their own services (Show like as Service not found)
## Why?
## How?
## Testing?
## Anything Else?