### PR TITLE
Feat(TR-sOU0W2hc): Update subscriptions and user profile UI

### DIFF
--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -11,22 +11,33 @@ import Icon from "../icons";
 import routePath from "@/config/route";
 import { cn } from "@/lib/utils";
 import { isLinkActive } from "@/utils/headerActive";
+import { useMemo } from "react";
+import { useUserStore } from "@/stores/user";
 
 const NAVIGATION_LINKS = [
   { name: "Trang chủ", href: "/" },
-  { name: "Dịch vụ", href: "/services" },
+  { name: "Gói dịch vụ", href: "/subscription" },
   { name: "Cửa hàng", href: "/store" },
   { name: "Tìm kiếm", href: "/services/search" },
   { name: "Liên hệ", href: "/contact" },
 ];
 
 export default function Header() {
-  const { isAuthenticated, logout } = useAuth();
+  const { isAuthenticated, logout, user } = useAuth();
+  const { reset } = useUserStore();
+
   const navigate = useNavigate();
+  const navigationLinksConverted = useMemo(() => {
+    if (user?.role !== "STORE") {
+      return NAVIGATION_LINKS.filter((item) => item.name !== "Gói dịch vụ");
+    }
+    return NAVIGATION_LINKS;
+  }, [user]);
 
   const handleLogout = async () => {
     try {
       await logout();
+      reset();
     } catch (error) {
       (error as Error).message = "Failed to logout";
       console.error("Logout failed:", error);
@@ -45,7 +56,7 @@ export default function Header() {
           </Link>
           <div className="hidden md:block">
             <div className="ml-10 flex items-baseline space-x-4">
-              {NAVIGATION_LINKS.map((item) => (
+              {navigationLinksConverted.map((item) => (
                 <Button key={item.name} asChild variant="link">
                   <Link
                     to={{ pathname: item.href }}

--- a/src/components/icons/glyphs/clock.tsx
+++ b/src/components/icons/glyphs/clock.tsx
@@ -17,4 +17,4 @@ export const Clock = ({ className = "", ...props }: GlyphIcon) => {
       <polyline points="12 6 12 12 16 14" />
     </svg>
   );
-}; 
+};

--- a/src/config/route.ts
+++ b/src/config/route.ts
@@ -16,7 +16,7 @@ const routePath = {
   manageUser: "/admin/manage-user",
   unauthorized: "/unauthorized",
   subscription: "/subscription",
-  paymentSuccess: "/payment-success",
+  paymentResult: "/payment-result",
 };
 
 export default routePath;

--- a/src/features/subscriptions/constants/pricing-plan.ts
+++ b/src/features/subscriptions/constants/pricing-plan.ts
@@ -7,7 +7,7 @@ export const PLANS: PricingPlan[] = [
     price: "0đ",
     description: "Gói cơ bản cho người bắt đầu",
     features: [
-      { text: "Nhận tối đa 20 đơn từ khách mỗi tháng", included: true },
+      { text: "Tối đa 20 đơn được hoàn thành", included: true },
       {
         text: "Không được ưu tiên hiển thị trong kết quả tìm kiếm",
         included: false,
@@ -26,7 +26,7 @@ export const PLANS: PricingPlan[] = [
     price: "80.000đ",
     description: "Mở khóa tất cả tính năng cao cấp",
     features: [
-      { text: "Không giới hạn số đơn", included: true },
+      { text: "Tối đa 100 đơn được hoàn thành", included: true },
       {
         text: "Ưu tiên hiển thị trên đầu trang khi khách tìm kiếm dịch vụ",
         included: true,
@@ -43,7 +43,7 @@ export const PLANS: PricingPlan[] = [
     price: "800.000đ",
     description: "Tiết kiệm 2 tháng phí",
     features: [
-      { text: "Không giới hạn số đơn", included: true },
+      { text: "Tối đa 100 đơn được hoàn thành mỗi tháng", included: true },
       {
         text: "Ưu tiên hiển thị trên đầu trang khi khách tìm kiếm dịch vụ",
         included: true,
@@ -52,7 +52,7 @@ export const PLANS: PricingPlan[] = [
     ],
     buttonText: "Nâng Cấp Ngay",
     badge: "10 tháng",
-    annualDiscount: "Tiết kiệm 20%",
+    annualDiscount: "Tiết kiệm 16%",
     type: "YEARLY",
   },
 ];

--- a/src/features/subscriptions/utils/subscription.ts
+++ b/src/features/subscriptions/utils/subscription.ts
@@ -1,0 +1,41 @@
+export function getSubscriptionPlanName(priority: number): string {
+  switch (priority) {
+    case 0:
+      return "Miễn phí";
+    case 1:
+      return "Gói tháng";
+    case 2:
+      return "Gói năm";
+    default:
+      return "Không xác định";
+  }
+}
+
+export function calculateRemainingDays(
+  createdAt: string,
+  priority: number
+): number {
+  if (!createdAt || priority === 0) return 0;
+
+  const startDate = new Date(createdAt);
+  const currentDate = new Date();
+
+  // Calculate end date based on subscription type
+  const endDate = new Date(startDate);
+  if (priority === 1) {
+    // Monthly plan - add 30 days
+    endDate.setDate(startDate.getDate() + 30);
+  } else if (priority === 2) {
+    // Yearly plan - add 365 days
+    endDate.setDate(startDate.getDate() + 365);
+  }
+
+  // If subscription has expired, return 0
+  if (currentDate > endDate) return 0;
+
+  // Calculate remaining days
+  const remainingTime = endDate.getTime() - currentDate.getTime();
+  const remainingDays = Math.ceil(remainingTime / (1000 * 60 * 60 * 24));
+
+  return remainingDays;
+}

--- a/src/features/user/api/user.api.ts
+++ b/src/features/user/api/user.api.ts
@@ -1,0 +1,20 @@
+import { axiosInstance } from "@/config/axios";
+import type { UserResponse } from "../types/user.types";
+
+const USER_ENDPOINTS = {
+  GET_BY_ID: "/users",
+};
+
+export const userApi = {
+  getUserById: async (id: number): Promise<UserResponse> => {
+    try {
+      const response = await axiosInstance.get<UserResponse>(
+        `${USER_ENDPOINTS.GET_BY_ID}/${id}`
+      );
+      return response.data;
+    } catch (error) {
+      console.error("Error fetching user info:");
+      throw error;
+    }
+  },
+};

--- a/src/features/user/hooks/useUser.ts
+++ b/src/features/user/hooks/useUser.ts
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+
+import { useAuthStore } from "@/stores/auth";
+import { useUserStore } from "@/stores/user";
+
+export const useUser = () => {
+  const { user: authUser } = useAuthStore();
+  const { getUser, user: userDetail } = useUserStore();
+  useEffect(() => {
+    async function fetchUser() {
+      if (authUser?.user_id && authUser.auth_status) {
+        await getUser(authUser.user_id, authUser.auth_status);
+      }
+    }
+    fetchUser();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { user: userDetail };
+};

--- a/src/features/user/service/user.service.ts
+++ b/src/features/user/service/user.service.ts
@@ -1,0 +1,12 @@
+import { userApi } from "../api/user.api";
+import type { UserResponse } from "../types/user.types";
+
+export const userService = {
+  /**
+   * Get user information from the API
+   * @returns Promise with user data
+   */
+  getUserInfo: async (id: number): Promise<UserResponse> => {
+    return await userApi.getUserById(id);
+  },
+};

--- a/src/features/user/types/profile.type.ts
+++ b/src/features/user/types/profile.type.ts
@@ -16,10 +16,24 @@ export interface ProfileResponse {
   user_ward: string;
   user_district: string;
   user_city: string;
+  user_priority: number;
   delete_flag: boolean;
   authentication_id: number;
   created_at: string;
   updated_at: string;
+  payments: {
+    payment_id: number | null;
+    transaction_id: string | null;
+    payment_description: string | null;
+    payment_type: string | null;
+    payment_status: string | null;
+    user_full_name: string | null;
+    payment_amount: number | null;
+    delete_flag: boolean | null;
+    user_id: number | null;
+    created_at: string | null;
+    updated_at: string | null;
+  };
   services?: Array<{
     service_name: string;
     service_description: string;

--- a/src/features/user/types/user.types.ts
+++ b/src/features/user/types/user.types.ts
@@ -1,0 +1,41 @@
+export interface UserResponse {
+  user_id: number;
+  user_full_name: string;
+  user_avatar_url: string | null;
+  user_alias: string;
+  user_description: string | null;
+  user_phone_number: string;
+  user_street: string;
+  user_ward: string;
+  user_district: string;
+  user_city: string;
+  user_priority: SubscriptionPlan;
+  delete_flag: boolean;
+  authentication_id: number;
+  created_at: string;
+  updated_at: string;
+  role: string;
+  favorite_id: number;
+}
+
+export enum SubscriptionPlan {
+  FREE = 0,
+  MONTHLY = 1,
+  YEARLY = 2,
+}
+
+export interface UserState {
+  user: UserResponse | null;
+}
+
+export interface UserStore extends UserState {
+  isLoading: boolean;
+  error: Error | null;
+  getUser: (
+    id: number,
+    isAuthenticated: boolean
+  ) => Promise<UserResponse | null>;
+  setUser: (user: UserResponse | null) => void;
+  updateUser: () => void;
+  reset: () => void;
+}

--- a/src/pages/subscription/list-plan/_components/subscription-item.tsx
+++ b/src/pages/subscription/list-plan/_components/subscription-item.tsx
@@ -13,6 +13,8 @@ import Icon from "@/components/icons";
 import type { PricingPlan } from "@/features/subscriptions/types/plan-pricing.type";
 import { useZaloPayCheckout } from "@/features/subscriptions/hooks/useZaloPayCheckout";
 import { toast } from "react-toastify";
+import { useUser } from "@/features/user/hooks/useUser";
+import { SubscriptionPlan } from "@/features/user/types/user.types";
 
 interface SubscriptionItemProps {
   plan: PricingPlan;
@@ -23,8 +25,32 @@ const fadeInUp = {
   visible: { opacity: 1, y: 0 },
 };
 
+const getCurrentPlan = (priority: number, planType: string) => {
+  if (planType === "free" && priority === SubscriptionPlan.FREE) {
+    return "Gói hiện tại";
+  }
+  if (planType === "monthly" && priority === SubscriptionPlan.MONTHLY) {
+    return "Gói hiện tại";
+  }
+  if (planType === "yearly" && priority === SubscriptionPlan.YEARLY) {
+    return "Gói hiện tại";
+  }
+  return null;
+};
+
+const alreadyHavePlan = (priority: number) => {
+  if (
+    priority === SubscriptionPlan.MONTHLY ||
+    priority === SubscriptionPlan.YEARLY
+  ) {
+    return true;
+  }
+  return false;
+};
+
 const SubscriptionItem = ({ plan }: SubscriptionItemProps) => {
   const { isLoading, error, initiatePayment } = useZaloPayCheckout();
+  const { user } = useUser();
 
   const handleSubscribe = async () => {
     if (plan.type === "FREE") {
@@ -119,9 +145,13 @@ const SubscriptionItem = ({ plan }: SubscriptionItemProps) => {
             onClick={handleSubscribe}
             isLoading={isLoading}
             loadingText="Đang xử lý..."
-            disabled={plan.id === "free"}
+            disabled={
+              plan.id === "free" ||
+              alreadyHavePlan(user?.user_priority as SubscriptionPlan)
+            }
           >
-            {plan.buttonText}
+            {getCurrentPlan(user?.user_priority as SubscriptionPlan, plan.id) ||
+              plan.buttonText}
           </Button>
         </CardFooter>
       </Card>

--- a/src/pages/subscription/list-plan/index.tsx
+++ b/src/pages/subscription/list-plan/index.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { motion } from "framer-motion";
 
 import { Button } from "@/components/ui/button";
@@ -22,10 +21,6 @@ const staggerContainer = {
 };
 
 const SubscriptionPage = () => {
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
-
   return (
     <div className="container mx-auto px-4 py-16">
       <motion.div

--- a/src/pages/subscription/payment-result/index.tsx
+++ b/src/pages/subscription/payment-result/index.tsx
@@ -4,16 +4,18 @@ import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import Icon from "@/components/icons";
 import { zalopayApi } from "@/features/subscriptions/api/zalopay-api";
+import { useUserStore } from "@/stores/user";
 
 const fadeIn = {
   hidden: { opacity: 0, y: 20 },
   visible: { opacity: 1, y: 0 },
 };
 
-const PaymentSuccessPage = () => {
+const PaymentResultPage = () => {
   const [isVerifying, setIsVerifying] = useState(true);
   const [isVerified, setIsVerified] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { updateUser } = useUserStore();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -36,6 +38,7 @@ const PaymentSuccessPage = () => {
         // Check if the payment was successful
         if (response.code === 1 && response.return_code === 1) {
           setIsVerified(true);
+          updateUser();
         } else {
           setError(response.return_message || "Không thể xác thực giao dịch");
         }
@@ -48,6 +51,7 @@ const PaymentSuccessPage = () => {
     };
 
     verifyPayment();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.search]);
 
   return (
@@ -130,4 +134,4 @@ const PaymentSuccessPage = () => {
   );
 };
 
-export default PaymentSuccessPage;
+export default PaymentResultPage;

--- a/src/pages/user/components/profile-sidebar.tsx
+++ b/src/pages/user/components/profile-sidebar.tsx
@@ -9,6 +9,12 @@ import { profileService } from "@/features/user/service/profile.service";
 import { convertToBase64 } from "@/utils/file";
 import { toast } from "react-toastify";
 import { Input } from "@/components/ui/input";
+import {
+  getSubscriptionPlanName,
+  calculateRemainingDays,
+} from "@/features/subscriptions/utils/subscription";
+import { Badge } from "@/components/ui/badge";
+
 interface ProfileSidebarProps {
   profile: ProfileResponse;
   onProfileChange: (profile: ProfileResponse) => void;
@@ -28,6 +34,12 @@ export function ProfileSidebar({
         year: "numeric",
       })
     : "";
+
+  const subscriptionPlan = getSubscriptionPlanName(profile.user_priority);
+  const remainingDays = calculateRemainingDays(
+    profile.created_at,
+    profile.user_priority
+  );
 
   const handleUploadClick = () => {
     fileInputRef.current?.click();
@@ -101,9 +113,7 @@ export function ProfileSidebar({
             Thay đổi ảnh
           </Button>
         </div>
-
         <Separator className="my-6 bg-primary/20" />
-
         <div className="space-y-4">
           {isStore && (
             <div className="flex items-center space-x-2">
@@ -115,6 +125,31 @@ export function ProfileSidebar({
             <Icon glyph="calendar" className="w-4 h-4 text-muted-foreground" />
             <span className="text-sm">Tham gia từ {joinDate}</span>
           </div>
+          {isStore && (
+            <div className="flex items-center space-x-2">
+              <Icon
+                glyph="checkCircle2"
+                className="w-4 h-4 text-muted-foreground"
+              />
+              <span className="text-sm">
+                Gói hiện tại:{" "}
+                <Badge variant="outline" className="ml-1 font-normal">
+                  {subscriptionPlan}
+                </Badge>
+              </span>
+            </div>
+          )}
+          {profile.user_priority > 0 && remainingDays > 0 && (
+            <div className="flex items-center space-x-2">
+              <Icon glyph="clock" className="w-4 h-4 text-muted-foreground" />
+              <span className="text-sm">
+                Còn lại:{" "}
+                <Badge variant="outline" className="ml-1 font-normal">
+                  {remainingDays} ngày
+                </Badge>
+              </span>
+            </div>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -23,8 +23,9 @@ import OrderManagement from "../pages/order/manage";
 import ManageReport from "@/pages/admin/manage-report";
 import ManageUser from "@/pages/admin/manage-user";
 import Unauthorized from "@/pages/admin/unauthorized";
-import Subscription from "@/pages/subscription";
-import PaymentSuccess from "@/pages/payment-success";
+import Subscription from "@/pages/subscription/list-plan";
+import PaymentResult from "@/pages/subscription/payment-result";
+import { StoreRoute } from "./store-route";
 
 const listRoute: Route[] = [
   {
@@ -154,12 +155,20 @@ const listRoute: Route[] = [
   },
   {
     path: routePath.subscription,
-    component: <Subscription />,
+    component: (
+      <StoreRoute>
+        <Subscription />
+      </StoreRoute>
+    ),
     layout: MainLayout,
   },
   {
-    path: routePath.paymentSuccess,
-    component: <PaymentSuccess />,
+    path: routePath.paymentResult,
+    component: (
+      <PrivateRoute>
+        <PaymentResult />
+      </PrivateRoute>
+    ),
     layout: MainLayout,
   },
 ];

--- a/src/routes/store-route.tsx
+++ b/src/routes/store-route.tsx
@@ -1,0 +1,22 @@
+import { Navigate } from "react-router-dom";
+import type { PrivateRouteProps } from "../types/routes.type";
+import { useAuth } from "@/features/auth/hooks/useAuth";
+import routePath from "@/config/route";
+
+export const StoreRoute = ({ children }: PrivateRouteProps) => {
+  const { isAuthenticated, user, isLoading } = useAuth();
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to={routePath.login} />;
+  }
+
+  if (user?.role !== "STORE") {
+    return <Navigate to={routePath.unauthorized} />;
+  }
+
+  return children;
+};

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -1,0 +1,53 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { UserResponse, UserStore } from "@/features/user/types/user.types";
+import { userService } from "@/features/user/service/user.service";
+
+const initialState = {
+  user: null,
+  isLoading: false,
+  error: null,
+};
+
+export const useUserStore = create<UserStore>()(
+  persist(
+    (set, get) => ({
+      ...initialState,
+      setUser: (user: UserResponse | null) => set({ user }),
+      getUser: async (id: number, isAuthenticated: boolean) => {
+        const { user } = get();
+        if (!user && isAuthenticated) {
+          set({ isLoading: true });
+          try {
+            const userData = await userService.getUserInfo(id);
+            set({ user: userData });
+          } catch (error) {
+            set({ error: error as Error });
+          } finally {
+            set({ isLoading: false });
+          }
+        }
+        return user;
+      },
+      updateUser: async () => {
+        try {
+          set({ isLoading: true });
+          const userData = await userService.getUserInfo(
+            get().user?.user_id as number
+          );
+          set({ user: userData });
+        } catch (error) {
+          set({ error: error as Error });
+        } finally {
+          set({ isLoading: false });
+        }
+      },
+      isLoading: false,
+      error: null,
+      reset: () => set(initialState),
+    }),
+    {
+      name: "user-storage",
+    }
+  )
+);


### PR DESCRIPTION
## What?
- Update subscription UI, routing, content in UI
  - Update folder structure of subscription following module approach
  - Update header (Only store can view subscription section)
  - Config user store for state management
  - Disable yearly plan when be in monthly plan and do it reverse.
  - Show current plan text if already had any subscription plan
- Update user profile UI
  - Show current plan and remaining date 
## Why?
## How?
## Testing?
## Screenshots (optional but required if implement ui) 
[
<img width="1017" alt="Screenshot 2025-04-27 at 22 39 49" src="https://github.com/user-attachments/assets/cbfd4cdd-c586-45e8-8c42-f0e4a2a6830c" />
](url)
<img width="1439" alt="Screenshot 2025-04-27 at 22 48 41" src="https://github.com/user-attachments/assets/8b3d5fdb-73a1-4a18-b880-98a2522a82d0" />

## Anything Else?